### PR TITLE
Adding common user-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ Request to https://www.example.com/women/shoes has timed out.
 ```
 ## Updates
 1. Monday 8<sup>th</sup> of July 2024 ~ `edit_outputs` Tidying up the output and adding in a timeout after 10 seconds with an error message.
+2. Monday 8<sup>th</sup> of July 2024 ~ `Headers` Adding common browser User-Agents, this acts more like curl (used my script IRL and the output compared to curl differed)

--- a/check_redirects.py
+++ b/check_redirects.py
@@ -7,6 +7,11 @@ from urllib.parse import urljoin
 
 
 def check_redirects(base_url, paths):
+    # Adding common browser User-Agents - to act more like curl
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+        'Referer': base_url,  # Adding a referer header
+    }
     # Loop through each path
     for path in paths:
         # Combine the base URL with the relative path


### PR DESCRIPTION
I tested out this script when applying redirects for work and the output wasn't as I was expecting (compared to `curl -I`)

Adding common `User_Agent`'s has corrected the issue:

The issue before:
```bash
$ python check_redirects.py https://www.<removed>.com /old-location
Processing URL: https://www.<removed>.com/old-location
Status code: 403
Final URL Location: https://www.<removed>.com/new-location

$ curl -IL https://www.<removed>.com/old-location
HTTP/2 302 
date: Mon, 08 Jul 2024 16:13:02 GMT
content-type: text/html; charset=iso-8859-1
location: https://www.<removed>.com/new-location
...

HTTP/2 200 
date: Mon, 08 Jul 2024 16:13:03 GMT
```
Now:
```bash
$ python check_redirects.py https://www.<removed>.com /old-location
Processing URL: https://www.<removed>.com/old-location
Status code: 200
Final URL Location: https://www.<removed>.com/new-location
```