### PR TITLE
Adding more headers and switching to HEAD

### DIFF
--- a/check_redirects.py
+++ b/check_redirects.py
@@ -15,6 +15,8 @@ def check_redirects(base_url, paths):
         'User-Agent': 'curl/7.64.1',
         'Accept': '*/*',
         'Referer': base_url,
+        'Connection': 'keep-alive',
+        'Accept-Encoding': 'gzip, deflate, br',
     }
     session.headers.update(headers)
 
@@ -27,7 +29,9 @@ def check_redirects(base_url, paths):
 
         try:
             # Send a GET request and allow redirects
-            response = requests.get(url, allow_redirects=True, timeout=10)
+            # response = requests.get(url, allow_redirects=True, timeout=10)
+            # Send a HEAD request to match curl -IL behavior
+            response = session.head(url, allow_redirects=True, timeout=10)
 
             # Get the final URL and status code after all redirects
             final_url = response.url


### PR DESCRIPTION
While using this tool with applying redirects I noticed that some redirects were reporting different end statues than a `curl -IL` would - I still compare against when issues are thrown up

Summary of Changes Made:
- Changed from `GET` to `HEAD` to mimic `curl -IL` more.
- Added more headers to mimic curl's default headers. (Thank you google!)
- Used a `requests.Session` to maintain headers and cookies across requests, to improve consistency.

